### PR TITLE
github:workflows: Revert changes to where env is specified because it…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ on:
 jobs:
   release:
     runs-on: ${{ inputs.github-runner }}
+    environment: ${{ inputs.environment }}
     env:
       CICD_TOKEN: ${{ secrets.CICD_TOKEN }}
       ACTION: ${{ inputs.action }} 

--- a/.github/workflows/sync-infra.yml
+++ b/.github/workflows/sync-infra.yml
@@ -34,7 +34,6 @@ jobs:
   testing:
     needs: filter_envs
     if: needs.filter_envs.outputs.testing == 'true' 
-    environment: testing
     uses: ./.github/workflows/provision-components.yml
     with:
       project: gcloud-infra-testing-aab1735b

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -29,6 +29,7 @@ on:
 
 jobs:
   apply:
+    envrionment: ${{ inputs.environment }}
     runs-on: ${{ inputs.github-runner }}
     defaults:
       run:


### PR DESCRIPTION
… affects env secrets availability